### PR TITLE
Resolved conflicts with Add&RemoveGUI

### DIFF
--- a/InstrumentServer/InstrumentServerGui.py
+++ b/InstrumentServer/InstrumentServerGui.py
@@ -214,7 +214,7 @@ class InstrumentServerWindow(QMainWindow):
                    "serial": str(dlg.serial_check.isChecked()),
                    "visa": str(dlg.visa_check.isChecked()),
                    "path": dlg.path_line.text()}
-                connect_result, msg = instrument_connection_service.add_instrument_to_database(details)
+                connect_result, msg = self._ics.add_instrument_to_database(details)
                 
                 if not connect_result: msg = "Failed. " + msg
                 msgBox = QMessageBox(self)
@@ -231,7 +231,7 @@ class InstrumentServerWindow(QMainWindow):
                                       "Are you sure you want to remove the instrument '{}'?".format(self.currently_selected_instrument))
         
         if button == QMessageBox.StandardButton.Yes:
-            msg = instrument_connection_service.remove_instrument_from_database(self.currently_selected_instrument)
+            msg = self._ics.remove_instrument_from_database(self.currently_selected_instrument)
             msgBox = QMessageBox(self)
             msgBox.setWindowTitle("Status")
             msgBox.setText(msg)

--- a/InstrumentServer/driverParser.py
+++ b/InstrumentServer/driverParser.py
@@ -11,7 +11,6 @@ from . import driverParserService as dps
 
 bp = Blueprint("driverParser", __name__,  url_prefix='/driverParser')
 ini_path = None
-config = RawConfigParser()
 
 
 def setLogger(logger: logging.Logger):
@@ -20,14 +19,13 @@ def setLogger(logger: logging.Logger):
 
 
 '''Parses driver from a given local path. Returns dictionary of the driver contents'''
-@bp.route('/')
+@bp.route('/', methods = ['POST'])
 def parseDriver():
     try:
         global ini_path
-        ini_path = request.form['driverPath']
+        ini_path = request.get_json()
 
-
-
+        config = RawConfigParser()
         config.read(ini_path)
         gen_settings = dps.getGenSettings(dict(config['General settings']), ini_path)
         model_options = dps.getModelOptions(dict(config['Model and options']))
@@ -43,11 +41,12 @@ def parseDriver():
 
 
 @bp.route('/addDriver')
-def addDriver(ini_path):
+def addDriver():
     try:
-        #global ini_path
-        #ini_path = request.form['driverPath']
+        global ini_path
+        ini_path = request.form['driverPath']
         
+        config = RawConfigParser()
         config.read(ini_path)
         gen_settings = dps.getGenSettings(dict(config['General settings']), ini_path)
         model_options = dps.getModelOptions(dict(config['Model and options']))
@@ -55,9 +54,7 @@ def addDriver(ini_path):
         quantities = dps.getQuantities({key: value for key, value in config._sections.items()\
                 if key not in ('General settings', 'Model and options', 'VISA settings')})
         return {'general_settings': gen_settings, 'model_and_options': model_options, 'visa': visa_settings, 'quantities': quantities}, 200
-        #return redirect(url_for('instrumentDB.addInstrument', details = json.dumps({'general_settings': gen_settings, 
-        #'model_and_options': model_options, 'visa': visa_settings, 'quantities': quantities})))
-
+        
     except Exception as e:
         my_logger.error(e.args)
         return jsonify(e.args), 400

--- a/InstrumentServer/instrumentDB.py
+++ b/InstrumentServer/instrumentDB.py
@@ -1,7 +1,10 @@
 import json
 from psycopg2.extensions import AsIs
+
 import logging
 from flask import request, current_app, g
+from psycopg2 import errors
+import requests
 from flask import Blueprint, jsonify
 from werkzeug.exceptions import (abort, BadRequestKeyError)
 
@@ -10,33 +13,47 @@ from . import driverParser as dp
 
 
 bp = Blueprint("instrumentDB", __name__,  url_prefix='/instrumentDB')
+UniqueViolation = errors.lookup('23505')
 
 def setLogger(logger: logging.Logger):
     global my_logger 
     my_logger = logger
 
 ''' Adds instrument details to the database '''
-@bp.route('/addInstrument')
+@bp.route('/addInstrument', methods=['GET', 'POST'])
 def addInstrument():
     try:        
-        global instrument_details
-        result = json.loads(request.args['details'])
-        details = result['details']
-        instrument_details = dp.addDriver(details['path'])[0]
-        connection = db.get_db()
-        cute_name = details['cute_name']
-        manufacturer = instrument_details['general_settings']['name']
+        details = request.get_json()
+        url = r'http://127.0.0.1:5000/driverParser/'
+        instrument_details = requests.post(url, json=details['path'])
+        if 300 > instrument_details.status_code <= 200:        
+            connection = db.get_db()
+            cute_name = details['cute_name']
+            instrument_details = instrument_details.json()
+            manufacturer = instrument_details['general_settings']['name']
+            
+            ids.addInstrumentInterface(connection, details, manufacturer)
+            ids.addGenSettings(connection, instrument_details['general_settings'], cute_name)
+            ids.addModelOptions(connection, instrument_details['model_and_options'], cute_name)
+            ids.addVisaSettings(connection, instrument_details['visa'], cute_name)
+            for quantity in instrument_details['quantities'].keys():
+                ids.addQuantity(connection, instrument_details['quantities'][quantity], cute_name)
+            connection.commit()
 
-        ids.addInstrumentInterface(connection, details, manufacturer)
-        ids.addGenSettings(connection, instrument_details['general_settings'], cute_name)
-        ids.addModelOptions(connection, instrument_details['model_and_options'], cute_name)
-        ids.addVisaSettings(connection, instrument_details['visa'], cute_name)
-        for quantity in instrument_details['quantities'].keys():
-            ids.addQuantity(connection, instrument_details['quantities'][quantity], cute_name)
-        connection.commit()
-
+            db.close_db(connection)
+            return jsonify("Instrument added."), 200
+        else:
+            raise FileNotFoundError
+        
+    except FileNotFoundError:
+        my_logger.error("Invalid driver path.")
+        return jsonify("Invalid driver path."), 400
+    
+    except UniqueViolation:
+        connection.rollback()
         db.close_db(connection)
-        return jsonify("Instrument added."), 200
+        my_logger.error("Instrument name already exists.")
+        return jsonify("Instrument name already exists."), 400   
 
     except Exception:
         my_logger.error(Exception.args)
@@ -69,7 +86,7 @@ def allInstruments():
 
 
 @bp.route('/getInstrument')
-def getInstruments():
+def getInstrument():
     try:
         instrument_name = request.args['cute_name']        
         connection = db.get_db()
@@ -79,18 +96,12 @@ def getInstruments():
         visa_settings = ids.getVisaSettings(connection, instrument_name)
         quantities = ids.getQuantities(connection, instrument_name)
 
-
-
-
+        db.close_db(connection)
         return jsonify({'instrument_interface' : instrument_interface, 'general_settings' : general_settings, 'model_and_options' : model_options, 'visa' : visa_settings, 'quantities' : quantities}), 200
 
-    except IndexError:
+    except BadRequestKeyError:
         my_logger.error('Invalid instrument name.')
         return jsonify('Invalid instrument name.'), 400
-
-    except BadRequestKeyError:
-        my_logger.error('No instrument name was given.')
-        return jsonify('No instrument name was given.'), 400
 
     except Exception:
         my_logger.error(Exception.args)
@@ -133,6 +144,23 @@ def setLatestValue():
         my_logger.error('Invalid instrument name or label.')
         return jsonify('Invalid instrument name or label.'), 400
 
+    except Exception:
+        my_logger.error(Exception.args)
+        return jsonify(Exception.args), 400
+    
+@bp.route('/removeInstrument')
+def removeInstrument():
+    try:
+        instrument_name = request.args['cute_name']        
+        connection = db.get_db()
+        ids.deleteInstrument(connection, instrument_name)
+        db.close_db(connection)
+        return jsonify('Instrument removed.'), 200
+    
+    except BadRequestKeyError:
+        my_logger.error('Invalid instrument name.')
+        return jsonify('Invalid instrument name.'), 400
+    
     except Exception:
         my_logger.error(Exception.args)
         return jsonify(Exception.args), 400

--- a/InstrumentServer/instrumentDBService.py
+++ b/InstrumentServer/instrumentDBService.py
@@ -1,3 +1,4 @@
+import json
 import psycopg2
 from psycopg2.extensions import AsIs
 
@@ -6,11 +7,11 @@ def addInstrumentInterface(connection, ins_interface: dict, manufacturer):
     table = 'instruments'
     with connection.cursor() as cursor:
 
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         columns, values = [], []
-
+        
         for column_name in column_names:
             if column_name[0] in ins_interface.keys():
                 if ins_interface[column_name[0]]:
@@ -30,7 +31,7 @@ def addGenSettings(connection, gen_settings: dict, cute_name):
 
     with connection.cursor() as cursor:
 
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         columns, values = [], []
@@ -52,7 +53,7 @@ def addModelOptions(connection, model_options: dict, cute_name):
     table = 'model_and_options'
     with connection.cursor() as cursor:
 
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         columns, values = [], []
@@ -88,7 +89,7 @@ def addVisaSettings(connection, visa_settings: dict, cute_name):
     table = 'visa'
     with connection.cursor() as cursor:
 
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         columns, values = [], []
@@ -109,11 +110,11 @@ def addQuantity(connection, quantity: dict, cute_name):
     table = 'quantities'
     with connection.cursor() as cursor:
 
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)           
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
-        columns, values = [], []        
-
+        columns, values = [], []
+        
         for column_name in column_names:
             if column_name[0] in quantity.keys():             
                 if column_name[0] == 'state_values':
@@ -129,7 +130,13 @@ def addQuantity(connection, quantity: dict, cute_name):
                 elif column_name[0] == 'option_values':
                     columns.append('option_values')
                     option_values = '{' + ','.join(quantity['option_values']) + '}'
-                    values.append(option_values)                    
+                    values.append(option_values)
+
+                elif column_name[0] == 'combo_cmd':
+                    columns.append('combo_cmd')
+                    combo_cmd = json.dumps(quantity['combo_cmd'])
+                    values.append(combo_cmd)
+
 
                 elif quantity[column_name[0]]:
                     columns.append(column_name[0])
@@ -145,7 +152,7 @@ def getInstrumentInterface(connection: object, instrument_name: str) -> dict:
     table = 'instruments'
     general_settings = {}
     with connection.cursor() as cursor:
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         column_names = tuple(column_name[0] for column_name in column_names)
@@ -162,7 +169,7 @@ def getGenSettings(connection: object, instrument_name: str) -> dict:
     table = 'general_settings'
     general_settings = {}
     with connection.cursor() as cursor:
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         column_names = tuple(column_name[0] for column_name in column_names)
@@ -181,7 +188,7 @@ def getModelOptions(connection: object, instrument_name: str) -> dict:
     model_options = {}
 
     with connection.cursor() as cursor:
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         column_names = tuple(column_name[0] for column_name in column_names)
@@ -201,7 +208,7 @@ def getVisaSettings(connection: object, instrument_name: str) -> dict:
     table = 'visa'
     visa_settings = {}
     with connection.cursor() as cursor:
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         column_names = tuple(column_name[0] for column_name in column_names)
@@ -219,7 +226,7 @@ def getQuantities(connection: object, instrument_name: str) -> dict:
     table = 'quantities'
     quantities = {}
     with connection.cursor() as cursor:
-        column_names_query = "SELECT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
+        column_names_query = "SELECT DISTINCT column_name FROM information_schema.columns WHERE table_name = '{table_name}';".format(table_name=table)            
         cursor.execute(column_names_query)
         column_names = cursor.fetchall()
         column_names = tuple(column_name[0] for column_name in column_names)
@@ -255,3 +262,11 @@ def setLatestValue(connection: object, latest_value: str, instrument_name: str, 
         query = f"UPDATE {table} SET latest_value = '{latest_value}' WHERE cute_name = '{instrument_name}' and label = '{label}'"
         cursor.execute(query)
         connection.commit()
+
+def deleteInstrument(connection: object, cute_name: str):
+    table_names = ['general_settings', 'model_and_options', 'visa', 'quantities', 'instruments']
+    with connection.cursor() as cursor:
+        for table in table_names:
+            delete_instrument_query = "DELETE FROM {table_name} WHERE cute_name = '{cute_name}';".format(table_name = table, cute_name = cute_name)
+            cursor.execute(delete_instrument_query)
+            connection.commit()

--- a/InstrumentServer/instrument_connection_service.py
+++ b/InstrumentServer/instrument_connection_service.py
@@ -106,19 +106,21 @@ class InstrumentConnectionService:
 
         return '{}::{}::{}'.format(TCPIP_INTERFACE, ip_address, END)
     
-def add_instrument_to_database(details: dict):
-    url = r'http://127.0.0.1:5000/instrumentDB/addInstrument'
-    response = requests.post(url, json=details)
-    if 300 > response.status_code <= 200:
-        return True, response.json()
-    else:
-        return False, response.json()
-    
-def remove_instrument_from_database(cute_name: str):
-    url = r'http://127.0.0.1:5000/instrumentDB/removeInstrument'
-    response = requests.get(url, params={'cute_name': cute_name})
-    if 300 > response.status_code <= 200:
-        return "Instrument removed."
-    else:
-        print(response.raise_for_status())
-    return "Failed to remove the instrument."
+    def add_instrument_to_database(self, details: dict):
+        url = r'http://127.0.0.1:5000/instrumentDB/addInstrument'
+        response = requests.post(url, json=details)
+        if 300 > response.status_code <= 200:
+            return True, response.json()
+        else:
+            return False, response.json()
+        
+    def remove_instrument_from_database(self, cute_name: str):
+        self.disconnect_instrument(cute_name)
+        
+        url = r'http://127.0.0.1:5000/instrumentDB/removeInstrument'
+        response = requests.get(url, params={'cute_name': cute_name})
+        if 300 > response.status_code <= 200:
+            return "Instrument removed."
+        else:
+            print(response.raise_for_status())
+        return "Failed to remove the instrument."

--- a/InstrumentServer/instrument_connection_service.py
+++ b/InstrumentServer/instrument_connection_service.py
@@ -106,3 +106,19 @@ class InstrumentConnectionService:
 
         return '{}::{}::{}'.format(TCPIP_INTERFACE, ip_address, END)
     
+def add_instrument_to_database(details: dict):
+    url = r'http://127.0.0.1:5000/instrumentDB/addInstrument'
+    response = requests.post(url, json=details)
+    if 300 > response.status_code <= 200:
+        return True, response.json()
+    else:
+        return False, response.json()
+    
+def remove_instrument_from_database(cute_name: str):
+    url = r'http://127.0.0.1:5000/instrumentDB/removeInstrument'
+    response = requests.get(url, params={'cute_name': cute_name})
+    if 300 > response.status_code <= 200:
+        return "Instrument removed."
+    else:
+        print(response.raise_for_status())
+    return "Failed to remove the instrument."


### PR DESCRIPTION
Merge Add and Remove GUI sections to main

Edits during and after previous merge attempts:
In driverParser.py:
Having a global config reader stores the previous parse results, causing errors for subsequent searches - made it local to the methods. Modified 'addDriver' POST method.

In InstrumentDB.py:
Modified addInstrument endpoint to redirect to 'addDriver'. Handled 'duplicate instrument', 'invalid driver' exceptions. Added 'removeInstrument' endpoint. Other changes: Handled minor exceptions.

In InrteumentDBService.py:
Added deleteInstrument function. Changed 'combo_cmd' quantity to be added into the DB as a JSON. Other changes: Noticed that the information_schema was modified - it now has duplicate columns. I will check this issue. Nevertheless, it is handled in the 'column_names_query' with using 'distinct' constraint.

In InstrumentServerGui.py:
Added 'Add' and 'Remove' buttons functionality. Created AddInstrument Window. Other changes: removed trailing spaces for 'cute_name' and 'address' text - to maintain uniqueness of 'cute_name'

In instrument_connection_service.py:
Added 'add_instrument_to_database' and 'remove_instrument_from_database' functions. These functions may be moved to a more suitable module. Other changes: Changed localhost in the urls to 127.0.0.1.