### PR TITLE
[NIST-51] Baud Rate override, Instrument address display update

### DIFF
--- a/Insrument/instrument_manager.py
+++ b/Insrument/instrument_manager.py
@@ -48,7 +48,6 @@ class InstrumentManager:
         self._startup()
 
     def _get_driver(self):
-        print('Getting the driver...')
         """Communicates with instrument server to get driver for instrument"""
         # implementation will likely change
         url = r'http://127.0.0.1:5000/instrumentDB/getInstrument'
@@ -60,12 +59,10 @@ class InstrumentManager:
             response.raise_for_status()
 
     def _initialize_instrument(self, connection):
-        print('Connecting to instrument...')
         """Initializes PyVISA resource if a PyVISA resource string was given at construction"""
         # string passed through in VISA form
         if isinstance(connection, str):
             self._rm = ResourceManager()
-            print('Got ResourceManager...')
 
             if self._is_serial_instrument():
                 # The actual terminating chars as str
@@ -79,7 +76,8 @@ class InstrumentManager:
                 # To connect a serial instrument, baud_rate and read_termination is required
                 self._instrument = self._rm.open_resource(resource_name=connection,
                                                           read_termination=read_term,
-                                                          baud_rate=self._baud_rate)
+                                                          baud_rate=self._baud_rate,
+                                                          open_timeout=10000)
             else:
                 print('Connecting to VISA instrument: {} using: {}'.format(self.name, connection))
                 self._instrument = self._rm.open_resource(connection)

--- a/InstrumentServer/InstrumentServerGui.py
+++ b/InstrumentServer/InstrumentServerGui.py
@@ -4,7 +4,6 @@ import logging
 from PyQt6.QtCore import *
 from PyQt6.QtWidgets import *
 from PyQt6.QtGui import *
-import os
 import db
 import instrument_connection_service
 from GUI.experimentWindowGui import ExperimentWindowGui
@@ -31,12 +30,6 @@ class InstrumentServerWindow(QMainWindow):
 
         # The parent flask application
         self.flask_app = flask_app
-
-        # Get the current working directory
-        cwd = os.getcwd()
-
-        # Print the current working directory
-        print("Current working directory: {0}".format(cwd))
 
         self.green_icon = QIcon("../Icons/greenIcon.png")
         self.red_icon = QIcon("../Icons/redIcon.png")
@@ -86,7 +79,7 @@ class InstrumentServerWindow(QMainWindow):
 
         self._ics = instrument_connection_service.InstrumentConnectionService(self.get_logger())
 
-        print('Done initializing Instrument Server GUI')
+        self.my_logger.info('Done initializing Instrument Server GUI')
 
     def get_logger(self):
         """Get the application logger"""
@@ -212,25 +205,25 @@ class InstrumentServerWindow(QMainWindow):
         print('Add was clicked')
         dlg = AddInstrumentWindow()
 
-        if dlg.exec():            
-            if not dlg.name_line.text() or not dlg.path_line.text() or (dlg.interface_choice.currentText() == "TCPIP" and not dlg.address_line.text()):
+        if dlg.exec():
+            if not dlg.name_line.text() or not dlg.path_line.text() or not dlg.address_line.text():
                 msgBox = QMessageBox(self)
                 msg = "Failed to add instrument. Please provide complete details."
                 msgBox.setWindowTitle("Add Instrument")
                 msgBox.setText(msg)
                 msgBox.exec()
-                print('Failed')
+                self.get_logger().debug('Missing required fields')
 
             else:
-                if dlg.interface_choice.currentText() != "TCPIP": dlg.address_line.setText("")
                 details = {"cute_name": dlg.name_line.text().strip(),
-                   "interface": dlg.interface_choice.currentText(),
-                   "ip_address": dlg.address_line.text().strip(),
-                   "serial": str(dlg.serial_check.isChecked()),
-                   "visa": str(dlg.visa_check.isChecked()),
-                   "path": dlg.path_line.text()}
+                           "interface": dlg.interface_choice.currentText(),
+                           "address": dlg.address_line.text().strip(),
+                           "baud_rate": dlg.baud_rate_line.text().strip(),
+                           "serial": str(dlg.serial_check.isChecked()),
+                           "visa": str(dlg.visa_check.isChecked()),
+                           "path": dlg.path_line.text()}
                 connect_result, msg = self._ics.add_instrument_to_database(details)
-                
+
                 if not connect_result: msg = "Failed. " + msg
                 msgBox = QMessageBox(self)
                 msgBox.setWindowTitle("Status")
@@ -238,13 +231,14 @@ class InstrumentServerWindow(QMainWindow):
                 msgBox.exec()
                 self.get_known_instruments()
         else:
-            print('Cancelled')
+            self.get_logger().debug('User hit cancel')
 
     def remove_btn_clicked(self):
         print('Remove was clicked')
         button = QMessageBox.question(self, "Remove Instrument",
-                                      "Are you sure you want to remove the instrument '{}'?".format(self.currently_selected_instrument))
-        
+                                      "Are you sure you want to remove the instrument '{}'?".format(
+                                          self.currently_selected_instrument))
+
         if button == QMessageBox.StandardButton.Yes:
             msg = self._ics.remove_instrument_from_database(self.currently_selected_instrument)
             msgBox = QMessageBox(self)
@@ -279,7 +273,7 @@ class InstrumentServerWindow(QMainWindow):
         self.get_logger().debug('Connect All was clicked')
 
         failed_connections = []
-        
+
         # iterate through instrument_tree and connect to instrument
         qtiter = QTreeWidgetItemIterator(self.instrument_tree)
         while qtiter.value():
@@ -302,7 +296,8 @@ class InstrumentServerWindow(QMainWindow):
             current_item = self.instrument_tree.currentItem()
             current_item.setIcon(0, self.red_icon)
         except KeyError:
-            QMessageBox.information(self, 'Instrument is not currently connected.', 'Instrument is not currently connected.')
+            QMessageBox.information(self, 'Instrument is not currently connected.',
+                                    'Instrument is not currently connected.')
         except Exception as e:
             QMessageBox.critical(self, 'Unknown Error', e)
 
@@ -370,14 +365,14 @@ class InstrumentServerWindow(QMainWindow):
                         cute_name = instrument[0]
                         manufacturer = instrument[1]
                         interface = instrument[2]
-                        ip_address = instrument[3]
+                        address = instrument[3]
                         serial = instrument[4]
-                        via = instrument[5]
+                        visa = instrument[5]
 
                         # If an IP Address was provided, use it for Address column, otherwise use the Interface
                         self.add_instrument_to_list(manufacturer,
                                                     cute_name,
-                                                    (ip_address if ip_address != None else interface))
+                                                    (address if address != None else interface))
 
             except Exception as ex:
                 self.get_logger().fatal(f'There was a problem getting all known instruments: {ex}')
@@ -395,7 +390,7 @@ class InstrumentServerWindow(QMainWindow):
         if not self._ics.is_connected(cute_name):
             self.connect_btn_clicked()
             return
-        
+
         try:
             instrument_manager = self._ics.get_instrument_manager(cute_name)
         except Exception as e:
@@ -404,40 +399,50 @@ class InstrumentServerWindow(QMainWindow):
 
         self.quantity_manager_gui = InstrumentManagerGUI(instrument_manager)
 
+
 class AddInstrumentWindow(QDialog):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Add Instrument")
+        self.setWindowTitle("Add New Instrument")
+        self.is_baud_rate_visible = False
+
+        # * Indicates a required field
 
         # Box 1 for driver file input
-        self.file_message = QLabel("File path:")
+        self.file_message = QLabel("File path: *")
         self.path_line = QLineEdit()
-        self.filebutton = QPushButton("Select File")
+        self.filebutton = QPushButton("Select File*")
         self.filebutton.clicked.connect(self.getFilePath)
 
         file_input_hbox = QHBoxLayout()
         file_input_hbox.addWidget(self.path_line)
         file_input_hbox.addWidget(self.filebutton)
 
-        file_input_vbox = QVBoxLayout()        
+        file_input_vbox = QVBoxLayout()
         file_input_vbox.addWidget(self.file_message)
         file_input_vbox.addLayout(file_input_hbox)
 
         self.file_group_box = QGroupBox("Instrument Driver")
-        self.file_group_box.setLayout(file_input_vbox)              
+        self.file_group_box.setLayout(file_input_vbox)
 
         # Box 2 for communication input
         self.name_line = QLineEdit()
         self.interface_choice = QComboBox()
         self.interface_choice.addItems(["TCPIP", "USB", "GPIB"])
         self.address_line = QLineEdit()
+        self.baud_rate_line = QLineEdit()
 
-        comm_form_layout = QFormLayout()
-        comm_form_layout.addRow(QLabel("Name:"), self.name_line)
-        comm_form_layout.addRow(QLabel("Interface:"), self.interface_choice)
-        comm_form_layout.addRow(QLabel("Address:"), self.address_line)
-                
+        self.comm_form_layout = QFormLayout()
+        self.comm_form_layout.insertRow(0, QLabel("Name: *"), self.name_line)
+        self.comm_form_layout.insertRow(1, QLabel("Interface: *"), self.interface_choice)
+        self.comm_form_layout.insertRow(2, QLabel("Address: *"), self.address_line)
+
+        # Only visible if the "Serial" checkbox is checked
+        self.comm_form_layout.insertRow(3, QLabel("Baud Rate:"), self.baud_rate_line)
+        self.hide_baud_rate()
+
         self.serial_check = QCheckBox("Serial")
+        self.serial_check.clicked.connect(self.serial_checkbox_clicked)
         self.visa_check = QCheckBox("VISA instrument")
 
         comm_input_hbox = QHBoxLayout()
@@ -445,12 +450,12 @@ class AddInstrumentWindow(QDialog):
         comm_input_hbox.addWidget(self.visa_check)
 
         comm_input_vbox = QVBoxLayout()
-        comm_input_vbox.addLayout(comm_form_layout)
+        comm_input_vbox.addLayout(self.comm_form_layout)
         comm_input_vbox.addLayout(comm_input_hbox)
 
         self.comm_group_box = QGroupBox("Communication")
-        self.comm_group_box.setLayout(comm_input_vbox)        
-       
+        self.comm_group_box.setLayout(comm_input_vbox)
+
         # Box 3 for Ok and Cancel inputs
         question_buttons = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         self.button_box = QDialogButtonBox(question_buttons)
@@ -465,11 +470,27 @@ class AddInstrumentWindow(QDialog):
         self.setLayout(self.layout)
         self.setFixedWidth(400)
 
-    def getFilePath(self):        
+    def getFilePath(self):
         file_filter = 'Configuration File (*.ini);; Python File (*.py)'
         initial_filter = 'Configuration File (*.ini)'
-        fileName = QFileDialog.getOpenFileName(parent = self, caption = "Select File", directory = "C:\\", filter = file_filter, initialFilter = initial_filter )
+        fileName = QFileDialog.getOpenFileName(parent=self, caption="Select File", directory="C:\\", filter=file_filter,
+                                               initialFilter=initial_filter)
         self.path_line.setText(fileName[0])
+
+    def show_baud_rate(self):
+        self.is_baud_rate_visible = True
+        self.comm_form_layout.setRowVisible(3, True)
+
+    def hide_baud_rate(self):
+        self.is_baud_rate_visible = False
+        self.comm_form_layout.setRowVisible(3, False)
+
+    def serial_checkbox_clicked(self):
+        if self.is_baud_rate_visible:
+            self.hide_baud_rate()
+        else:
+            self.show_baud_rate()
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)

--- a/InstrumentServer/InstrumentServerGui.py
+++ b/InstrumentServer/InstrumentServerGui.py
@@ -8,7 +8,15 @@ import db
 import instrument_connection_service
 from GUI.experimentWindowGui import ExperimentWindowGui
 from GUI.instrument_manager_gui import InstrumentManagerGUI
+from enum import Enum
 
+class INST_INTERFACE(Enum):
+    USB = 'USB'
+    GPIB = 'GPIB'
+    TCPIP = 'TCPIP'
+    SERIAL = 'SERIAL'
+    ASRL = 'ASRL'
+    COM = 'COM'
 
 ###################################################################################
 # InstrumentServerWindow
@@ -234,7 +242,7 @@ class InstrumentServerWindow(QMainWindow):
             self.get_logger().debug('User hit cancel')
 
     def remove_btn_clicked(self):
-        print('Remove was clicked')
+        self.get_logger().debug('Remove was clicked')
         button = QMessageBox.question(self, "Remove Instrument",
                                       "Are you sure you want to remove the instrument '{}'?".format(
                                           self.currently_selected_instrument))
@@ -369,10 +377,16 @@ class InstrumentServerWindow(QMainWindow):
                         serial = instrument[4]
                         visa = instrument[5]
 
+                        # The actual address to be displayed
+                        display_address = address
+
+                        if interface == INST_INTERFACE.GPIB.name:
+                            display_address = f'{interface}::{address}'
+
                         # If an IP Address was provided, use it for Address column, otherwise use the Interface
                         self.add_instrument_to_list(manufacturer,
                                                     cute_name,
-                                                    (address if address != None else interface))
+                                                    display_address)
 
             except Exception as ex:
                 self.get_logger().fatal(f'There was a problem getting all known instruments: {ex}')

--- a/InstrumentServer/instrumentDB.py
+++ b/InstrumentServer/instrumentDB.py
@@ -38,7 +38,7 @@ def addInstrument():
             # If the baud rate is provided, we will overwrite the value we got from the ini file
             if details['baud_rate']:
                 my_logger.debug(f"Baud Rate: {details['baud_rate']} was provided. Replacing value from ini file.")
-                ids.update_visa_baud_rate(connection, details['baud_rate'])
+                ids.update_visa_baud_rate(connection, cute_name, details['baud_rate'])
 
             db.close_db(connection)
             return jsonify("Instrument added."), 200
@@ -68,12 +68,12 @@ def allInstruments():
         all_instruments = {}
 
         with connection.cursor() as cursor:
-            all_instruments_query = "SELECT cute_name, manufacturer, interface, ip_address FROM {table_name};".format(table_name="instruments")           
+            all_instruments_query = "SELECT cute_name, manufacturer, interface, address FROM {table_name};".format(table_name="instruments")
             cursor.execute(all_instruments_query)
             result = cursor.fetchall()
 
             for instrument in result:
-                all_instruments[instrument[0]] = {'manufacturer': instrument[1], 'interface': instrument[2], 'ip_address': instrument[3]}
+                all_instruments[instrument[0]] = {'manufacturer': instrument[1], 'interface': instrument[2], 'address': instrument[3]}
 
         db.close_db(connection)
         if len(all_instruments) == 0:

--- a/InstrumentServer/instrumentDB.py
+++ b/InstrumentServer/instrumentDB.py
@@ -1,15 +1,10 @@
-import json
-from psycopg2.extensions import AsIs
-
 import logging
 from flask import request, current_app, g
 from psycopg2 import errors
 import requests
 from flask import Blueprint, jsonify
 from werkzeug.exceptions import (abort, BadRequestKeyError)
-
 import db, instrumentDBService as ids
-import driverParser as dp
 
 
 bp = Blueprint("instrumentDB", __name__,  url_prefix='/instrumentDB')
@@ -39,6 +34,11 @@ def addInstrument():
             for quantity in instrument_details['quantities'].keys():
                 ids.addQuantity(connection, instrument_details['quantities'][quantity], cute_name)
             connection.commit()
+
+            # If the baud rate is provided, we will overwrite the value we got from the ini file
+            if details['baud_rate']:
+                my_logger.debug(f"Baud Rate: {details['baud_rate']} was provided. Replacing value from ini file.")
+                ids.update_visa_baud_rate(connection, details['baud_rate'])
 
             db.close_db(connection)
             return jsonify("Instrument added."), 200

--- a/InstrumentServer/instrumentDBService.py
+++ b/InstrumentServer/instrumentDBService.py
@@ -270,3 +270,11 @@ def deleteInstrument(connection: object, cute_name: str):
             delete_instrument_query = "DELETE FROM {table_name} WHERE cute_name = '{cute_name}';".format(table_name = table, cute_name = cute_name)
             cursor.execute(delete_instrument_query)
             connection.commit()
+
+
+def update_visa_baud_rate(connection: object, cute_name: str, new_baud_rate):
+    table = 'visa'
+    with connection.cursor() as cursor:
+        query = f"UPDATE {table} SET baud_rate= '{new_baud_rate}' WHERE cute_name= '{cute_name}';"
+        cursor.execute(query)
+        connection.commit()

--- a/InstrumentServer/instrument_connection_service.py
+++ b/InstrumentServer/instrument_connection_service.py
@@ -2,6 +2,7 @@ import pyvisa
 import requests
 import logging
 from enum import Enum
+from http import HTTPStatus
 from Insrument.instrument_manager import InstrumentManager
 
 class INST_INTERFACE(Enum):
@@ -35,15 +36,14 @@ class InstrumentConnectionService:
         response = requests.get(url, params={'cute_name': cute_name})
 
         # raise exception for error
-        if 200 < response.status_code >= 300:
+        if HTTPStatus.OK < response.status_code >= HTTPStatus.MULTIPLE_CHOICES:
             response.raise_for_status()
 
         response_dict = dict(response.json())
         interface = response_dict['instrument_interface']['interface']
+        address = response_dict['instrument_interface']['address']
 
-        # Might be None
-        ip_address = response_dict['instrument_interface']['ip_address']
-        self.get_logger().debug(f'Cute_name {cute_name} uses interface: {interface}')
+        self.get_logger().debug(f'Cute_name: {cute_name} uses interface: {interface} and address: {address}')
 
         # Get list of resources to compare to
         rm = pyvisa.ResourceManager()
@@ -51,24 +51,23 @@ class InstrumentConnectionService:
         connection_str = None
 
         if interface == INST_INTERFACE.TCPIP.name:
-            self.get_logger().debug(f'TCPIP instrument IP address is {ip_address}')
-            connection_str = self.make_conn_str_tcip_instrument(ip_address)
+            connection_str = self.make_conn_str_tcip_instrument(address)
         else:
             # Get the connection string (used to get PyVISA resource)
             for resource in resources:
-                if interface in resource:
+                if interface in resource and address in resource:
                     connection_str = resource
                     break
 
         if connection_str is None:
-            raise ConnectionError(f"Could not connect to {cute_name}. Unable to find valid connection string.")
+            raise ConnectionError(f"Could not connect to {cute_name}. Available resources are: {resources}")
 
         # Connect to instrument
         self.get_logger().debug('Using connection string: {connection_str} to connect to {cute_name}')
         try:
             im = InstrumentManager(cute_name, connection_str)
             self._connected_instruments[cute_name] = im
-            self.get_logger().debug(f"Connected to {cute_name}.")
+            self.get_logger().debug(f"VISA connection established to: {cute_name}.")
         # InstrumentManager may throw value error, this service should throw a Connection error
         except ValueError as e:
             raise ConnectionError(e)
@@ -100,7 +99,7 @@ class InstrumentConnectionService:
         return self._connected_instruments[cute_name]
 
 
-    def make_conn_str_tcip_instrument(self, ip_address: str) -> str:
+    def make_conn_str_tcip_instrument(self, address: str) -> str:
         """
         Construct a connection string for TCPIP instruments
         Example: TCPIP0::192.168.0.7::INSTR
@@ -109,12 +108,12 @@ class InstrumentConnectionService:
         TCPIP_INTERFACE = 'TCPIP0'
         END = 'INSTR'
 
-        return f'{TCPIP_INTERFACE}::{ip_address}::{END}'
+        return f'{TCPIP_INTERFACE}::{address}::{END}'
     
     def add_instrument_to_database(self, details: dict):
         url = r'http://127.0.0.1:5000/instrumentDB/addInstrument'
         response = requests.post(url, json=details)
-        if 300 > response.status_code <= 200:
+        if HTTPStatus.MULTIPLE_CHOICES > response.status_code <= HTTPStatus.OK:
             return True, response.json()
         else:
             return False, response.json()
@@ -124,7 +123,7 @@ class InstrumentConnectionService:
         
         url = r'http://127.0.0.1:5000/instrumentDB/removeInstrument'
         response = requests.get(url, params={'cute_name': cute_name})
-        if 300 > response.status_code <= 200:
+        if HTTPStatus.MULTIPLE_CHOICES > response.status_code <= HTTPStatus.OK:
             return "Instrument removed."
         else:
             print(response.raise_for_status())

--- a/InstrumentServer/schema.sql
+++ b/InstrumentServer/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS instruments (
 	cute_name TEXT PRIMARY KEY NOT NULL,
 	manufacturer TEXT NOT NULL,
 	interface TEXT NOT NULL, 
-	ip_address TEXT,
+	address TEXT,
 	serial BOOLEAN,
 	visa BOOLEAN
 );


### PR DESCRIPTION
- Changed column `ip_address` in `instruments` table to just `address`
- When adding a new instrument, if the user checks the `Serial` checkbox, a new field pops up to override the baud rate if provided. The `baud_rate` in `visa` table will be updated (baud rate is initially obtained from `.ini` file). This field is optional. If it's left empty, the value obtained for `.ini` file will be used. 
- Added some address display updates requested by Flo

![image](https://user-images.githubusercontent.com/15895137/224712074-1fdb55a7-4875-4dee-9459-78919c0e9ba2.png)
