### PR TITLE
Users can now specify absolute or relative paths to custom InstrumentManager

### DIFF
--- a/InstrumentServer/driverParserService.py
+++ b/InstrumentServer/driverParserService.py
@@ -1,3 +1,5 @@
+import os
+
 '''
     Takes dictionary of just section ['General settings'] and the path of the .ini driver
     Returns dictionary with all keys and values (given and default) as defined by section 12.1.2 in Labber manual
@@ -40,8 +42,8 @@ def getGenSettings(settings: dict, ini_path) -> dict:
 
     return {
         'name': settings['name'],
-        'ini_path': ini_path,
-        'driver_path': driver_path,
+        'ini_path': ini_path.replace('/', os.sep),
+        'driver_path': driver_path.replace('/', os.sep),
         'interface': interface,
         'address': address,
         'startup': startup,

--- a/InstrumentServer/instrument_connection_service.py
+++ b/InstrumentServer/instrument_connection_service.py
@@ -91,13 +91,24 @@ class InstrumentConnectionService:
             # importing custom driver module from the driver_path
             # Assumption: driver_path and driver are the same
             driver_path = driver_dict["general_settings"]["driver_path"]
-            module_location = os.sep.join(driver_path.split(os.sep)[:-1])
-            module_name = driver_path.split(os.sep)[-1].replace(".py", "")
 
+            # if absolute path, use that exact file
+            if os.path.isabs(driver_path):
+                module_location = os.sep.join(driver_path.split(os.sep)[:-1])
+                module_name = driver_path.split(os.sep)[-1].replace(".py", "")
+            # if relative path, use the drictory of the ini file as starting point
+            else:
+                ini_path = driver_dict["general_settings"]["ini_path"]
+                module_location = os.sep.join(ini_path.split(os.sep)[:-1])
+                module_name = driver_path.split(os.sep)[-1].replace(".py", "")
+
+            # set environment to look at location
             sys.path.append(module_location)
-            custom_driver = importlib.import_module(module_name)
 
+            # import module
+            custom_driver = importlib.import_module(module_name)
             ManagerClass = getattr(custom_driver, module_name)
+
         else:
             ManagerClass = InstrumentManager
 
@@ -125,15 +136,26 @@ class InstrumentConnectionService:
         try:
             # importing custom driver module from the driver_path
             driver_path = response_dict["general_settings"]["driver_path"]
-            if os.path.exists(driver_path):
-                self._my_logger.info(f"Custom module file {driver_path} exists.")
-            print("PLEASE WORK----------------------------")
-            print(driver_path)
-            module_name = driver_path.split(os.sep)[-1].replace(".py", "")
-            print(module_name)
-            module_location = os.sep.join(driver_path.split(os.sep)[:-1])
+
+            # if absolute path, use that exact file
+            if os.path.isabs(driver_path):
+                module_location = os.sep.join(driver_path.split(os.sep)[:-1])
+                module_name = driver_path.split(os.sep)[-1].replace(".py", "")
+            # if relative path, use the drictory of the ini file as starting point
+            else:
+                ini_path = response_dict["general_settings"]["ini_path"]
+                ini_location = os.sep.join(ini_path.split(os.sep)[:-1])
+
+                module_location = ini_location + os.sep + os.sep.join(driver_path.split(os.sep)[:-1])
+                module_name = driver_path.split(os.sep)[-1].replace(".py", "")
+
+            # set environment to look at location
             sys.path.append(module_location)
+
+            # import module
             custom_driver = importlib.import_module(module_name)
+
+            # create connection
             im = getattr(custom_driver, module_name)(name=cute_name, driver=response_dict, logger=self.my_logger)
             self._connected_instruments[cute_name] = im
 


### PR DESCRIPTION
Updated driver parser to store correct path separator in database

updated connection service to get custom IM for both absolute and relative paths of the driver_path in DB. If it is relative, it uses the directory of the ini file as the starting point