### PR TITLE
[NIST-88] Add Server Start Script

### DIFF
--- a/GUI/experimentWindowGui.py
+++ b/GUI/experimentWindowGui.py
@@ -1,10 +1,6 @@
-import logging
-from PyQt6.QtCore import *
-from PyQt6.QtWidgets import *
-from PyQt6.QtGui import *
+import os.path
 from GUI.experiment_runner_gui import ExperimentRunner
 
-from GUI.quantity_frames import *
 from GUI.channels_table import *
 from GUI.sequence_table import *
 from GUI.log_channels_table import *
@@ -21,10 +17,10 @@ class ExperimentWindowGui(QMainWindow):
         self.resize(1000, 800)
         self._ics = ics
         self._working_instruments = dict()
-
+        self.icons_dir = parent_gui.icons_dir
         self.experiment_DTO = None
 
-        lab_experiment_icon = QIcon("../Icons/labExperiment.png")
+        lab_experiment_icon = QIcon(os.path.join(parent_gui.icons_dir, 'labExperiment.png'))
         self.setWindowIcon(lab_experiment_icon)
 
         # Experiment runner GUI
@@ -147,7 +143,7 @@ class ExperimentWindowGui(QMainWindow):
         # The main widget in for this section
         self.right_side_section = QVBoxLayout()
 
-        play_icon = QIcon("../Icons/playButton.png")
+        play_icon = QIcon(os.path.join(self.icons_dir, "playButton.png"))
         experiment_runner_btn = QPushButton("Experiment Runner")
         experiment_runner_btn.setIcon(play_icon)
         experiment_runner_btn.clicked.connect(self.experiment_runner_clicked)

--- a/GUI/experiment_runner_gui.py
+++ b/GUI/experiment_runner_gui.py
@@ -164,7 +164,8 @@ class ExperimentRunner(ManagedWindow):
         # A reference to the invoking GUI
         self.parent_gui = parent_gui      
 
-        play_icon = QIcon("../Icons/playButton.png")
+        self.icons_dir = parent_gui.icons_dir
+        play_icon = QIcon(os.path.join(self.icons_dir, "playButton.png"))
         self.setWindowIcon(play_icon)
 
         # The logger

--- a/InstrumentServer/InstrumentServerGui.py
+++ b/InstrumentServer/InstrumentServerGui.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from http import HTTPStatus
 
 import requests
@@ -14,6 +15,7 @@ from GUI.experimentWindowGui import ExperimentWindowGui
 from GUI.instrument_manager_gui import InstrumentManagerGUI
 from enum import Enum
 from GUI.instrument_settings_gui import InstrumentSettingsGUI
+from collections import OrderedDict
 
 
 class INST_INTERFACE(Enum):
@@ -46,28 +48,48 @@ class InstrumentServerWindow(QMainWindow):
         # The parent flask application
         self.flask_app = flask_app
 
-        self.green_icon = QIcon("../Icons/greenIcon.png")
-        self.red_icon = QIcon("../Icons/redIcon.png")
-
         # The "top most" layout is vertical box layout (top -> bottom)
         self.main_layout = QVBoxLayout()
 
         # This is the outermost widget
         self.main_widget = QWidget()
 
-        self.setWindowTitle("Instrument Server")
+        parent_dir = os.getcwd()
+        self.my_logger.debug(f'InstrumentServerWindow current working directory: {parent_dir}')
 
-        server_icon = QIcon("../Icons/servers.png")
+        # Split path using OS specific separator
+        list_of_str = parent_dir.split(os.sep)
+
+        # Create Dict that preserves order of list_of_str
+        ordered_dict = OrderedDict.fromkeys(list_of_str)
+
+        # Concern the dict keys back to list
+        set_with_order = list(ordered_dict.keys())
+
+        # Add OS separator for driver (usually C)
+        set_with_order[0] = set_with_order[0] + os.sep
+
+        # Construct a valid parent dir path
+        parent_dir = os.path.join(*set_with_order)
+
+        # Set Icons directory
+        self.icons_dir = os.path.join(parent_dir, "Icons")
+        self.my_logger.info(f'Icons directory: {self.icons_dir}')
+
+        server_icon = QIcon(os.path.join(self.icons_dir, "servers.png"))
+        self.green_icon = QIcon(os.path.join(self.icons_dir, "greenIcon.png"))
+        self.red_icon = QIcon(os.path.join(self.icons_dir, "redIcon.png"))
+        self.settings_icon = QIcon(os.path.join(self.icons_dir, "gear.png"))
+        self.remove_icon = QIcon(os.path.join(self.icons_dir, "delete.png"))
+        self.add_icon = QIcon(os.path.join(self.icons_dir, "add.png"))
+        self.create_experiment_icon = QIcon(os.path.join(self.icons_dir, "edit.png"))
+        self.connect_icon = QIcon(os.path.join(self.icons_dir, "connection.png"))
+        self.connect_all_icon = QIcon(os.path.join(self.icons_dir, "connection_multiple.png"))
+        self.close_icon = QIcon(os.path.join(self.icons_dir, "unlink.png"))
+        self.close_all_icon = QIcon(os.path.join(self.icons_dir, "disconnect_all.png"))
+
         self.setWindowIcon(server_icon)
-
-        self.settings_icon = QIcon("../Icons/gear.png")
-        self.remove_icon = QIcon("../Icons/delete.png")
-        self.add_icon = QIcon("../Icons/add.png")
-        self.create_experiment_icon = QIcon("../Icons/edit.png")
-        self.connect_icon = QIcon("../Icons/connection.png")
-        self.connect_all_icon = QIcon("../Icons/connection_multiple.png")
-        self.close_icon = QIcon("../Icons/unlink.png")
-        self.close_all_icon = QIcon("../Icons/disconnect_all.png")
+        self.setWindowTitle("Instrument Server")
 
         self.construct_menu()
 

--- a/InstrumentServer/__init__.py
+++ b/InstrumentServer/__init__.py
@@ -11,7 +11,7 @@ def main():
     Creates & Deploys Instrument Server
     Add dev_mode=True to NOT load a VISA backend (required to connect to instruments).
     """
-    server = flask_instrument_server.FlaskInstrumentServer(dev_mode=True)
+    server = flask_instrument_server.FlaskInstrumentServer()
     server.run_server()
 
 

--- a/pythonPath.bat
+++ b/pythonPath.bat
@@ -1,0 +1,7 @@
+@ECHO OFF
+
+Rem This script uses Python in "venv" virtual environment and sets PYTHONPATH var
+setlocal
+set PYTHONPATH=%1
+venv\Scripts\python.exe %2 %3
+endlocal

--- a/setupEnv.bat
+++ b/setupEnv.bat
@@ -1,16 +1,15 @@
 @echo off
 
-echo "This script will install virtualenv & setup a Python Virtual Enviroment -> venv"
+echo "This script will install virtualenv & setup a Python Virtual Environment -> venv"
 pause
 
 echo "Installing Python virtualenv"
+echo "Checking for pip updates..."
 py -m pip install --upgrade pip
 pip install virtualenv
 
 echo:
-echo "Creating venv virtual enviroment in current directory..."
+echo "Creating venv virtual environment in current directory..."
 
 py -m venv venv
 venv\Scripts\activate
-
-echo "Done!"

--- a/startServer.bat
+++ b/startServer.bat
@@ -1,0 +1,7 @@
+@echo off
+
+Rem This script starts Instrument Server - can just be clicked
+echo "Starting Instrument Server"
+timeout 2
+
+CALL pythonPath.bat %cd% InstrumentServer/__init__.py


### PR DESCRIPTION
- Instrument Server can now be deployed by just clicking on  `startServer.bat`
  - Uses Python in `venv` (installed pip packages)
  - Sets correct `PYTHONPATH` environment var (so all paths resolve properly) 
  
  
![image](https://user-images.githubusercontent.com/15895137/236740073-b878f889-256b-442d-993d-8bceb8e52c10.png)
